### PR TITLE
Task: Add `multivaluefield` to composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "silverstripe/framework": "^5.0",
-        "silverstripe/admin": "^2.0"
+        "silverstripe/admin": "^2.0",
+        "symbiote/silverstripe-multivaluefield": "^6.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
I was trying it out, and when I landed on the api-builder endpoint it was complaining the `multivaluefield` and couldnt be found. Need to add the composer requirement

## Issues
Not created one as its a simple one

